### PR TITLE
Implement extra Rescale Classifier-Free Guidance features and UI options

### DIFF
--- a/dynthres_core.py
+++ b/dynthres_core.py
@@ -14,7 +14,7 @@ class DynThreshVariabilityMeasure(enum.IntEnum):
     AD = 1
 
 class DynThresh:
-    def __init__(self, mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure,interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, power_val, experiment_mode, maxSteps):
+    def __init__(self, mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure,interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, maxSteps):
         self.mimic_scale = mimic_scale
         self.threshold_percentile = threshold_percentile
         self.mimic_mode = mimic_mode
@@ -23,7 +23,7 @@ class DynThresh:
         self.cfg_scale_min = cfg_scale_min
         self.mimic_scale_min = mimic_scale_min
         self.experiment_mode = experiment_mode
-        self.power_val = power_val
+        self.sched_val  = sched_val
 
         self.sep_feat_channels = separate_feature_channels
         self.scaling_startpoint = scaling_startpoint
@@ -48,9 +48,18 @@ class DynThresh:
         elif mode == "Cosine Up":
             scale *= 1.0 - math.cos((self.step / max) * 1.5707)
         elif mode == "Power Up":
-            scale *= math.pow(self.step / max, self.power_val)
+            scale *= math.pow(self.step / max, self.sched_val)
         elif mode == "Power Down":
-            scale *= 1.0 - math.pow(self.step / max, self.power_val)
+            scale *= 1.0 - math.pow(self.step / max, self.sched_val)
+        elif mode == "Linear Repeating":
+            portion = ((self.step / max) * self.sched_val) % 1.0
+            start = math.floor(portion)
+            portion -= start
+            scale *= (0.5 - portion) * 2 if portion < 0.5 else (portion - 0.5) * 2
+        elif mode == "Cosine Repeating":
+            scale *= math.cos((self.step / max) * 6.28318 * self.sched_val) * 0.5 + 0.5
+        elif mode == "Sawtooth":
+            scale *= ((self.step / max) * self.sched_val) % 1.0
         scale += min
         return scale
 

--- a/dynthres_core.py
+++ b/dynthres_core.py
@@ -14,7 +14,7 @@ class DynThreshVariabilityMeasure(enum.IntEnum):
     AD = 1
 
 class DynThresh:
-    def __init__(self, mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure,interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, maxSteps):
+    def __init__(self, mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure,interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, maxSteps):
         self.mimic_scale = mimic_scale
         self.threshold_percentile = threshold_percentile
         self.mimic_mode = mimic_mode

--- a/dynthres_core.py
+++ b/dynthres_core.py
@@ -14,7 +14,7 @@ class DynThreshVariabilityMeasure(enum.IntEnum):
     AD = 1
 
 class DynThresh:
-    def __init__(self, mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure,interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, maxSteps):
+    def __init__(self, mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, maxSteps):
         self.mimic_scale = mimic_scale
         self.threshold_percentile = threshold_percentile
         self.mimic_mode = mimic_mode

--- a/dynthres_core.py
+++ b/dynthres_core.py
@@ -23,7 +23,7 @@ class DynThresh:
         self.cfg_scale_min = cfg_scale_min
         self.mimic_scale_min = mimic_scale_min
         self.experiment_mode = experiment_mode
-        self.sched_val  = sched_val
+        self.sched_val = sched_val
 
         self.sep_feat_channels = separate_feature_channels
         self.scaling_startpoint = scaling_startpoint
@@ -53,8 +53,6 @@ class DynThresh:
             scale *= 1.0 - math.pow(self.step / max, self.sched_val)
         elif mode == "Linear Repeating":
             portion = ((self.step / max) * self.sched_val) % 1.0
-            start = math.floor(portion)
-            portion -= start
             scale *= (0.5 - portion) * 2 if portion < 0.5 else (portion - 0.5) * 2
         elif mode == "Cosine Repeating":
             scale *= math.cos((self.step / max) * 6.28318 * self.sched_val) * 0.5 + 0.5

--- a/dynthres_core.py
+++ b/dynthres_core.py
@@ -13,7 +13,6 @@ class DynThresh:
         self.mimic_scale_min = mimic_scale_min
         self.experiment_mode = experiment_mode
         self.sched_val = sched_val
-
         self.sep_feat_channels = separate_feature_channels
         self.scaling_startpoint = scaling_startpoint
         self.variability_measure = variability_measure
@@ -77,8 +76,6 @@ class DynThresh:
         mim_centered = mim_flattened - mim_means
         cfg_centered = cfg_flattened - cfg_means
 
-        ### Get the maximum value of all datapoints (with an optional threshold percentile on the uncond)
-
         if self.sep_feat_channels:
             if self.variability_measure == 'AD':
                 min_scaleref = mim_centered.abs().max(dim=2).values.unsqueeze(2)
@@ -97,11 +94,12 @@ class DynThresh:
 
         if self.scaling_startpoint == 'MEAN':
             if self.variability_measure == 'AD':
-                max_scalref = torch.maximum(min_scaleref, cfg_scaleref)
+                ### Get the maximum value of all datapoints (with an optional threshold percentile on the uncond)
+                max_scaleref = torch.maximum(min_scaleref, cfg_scaleref)
                 ### Clamp to the max
-                cfg_clamped = cfg_centered.clamp(-max_scalref, max_scalref)
+                cfg_clamped = cfg_centered.clamp(-max_scaleref, max_scaleref)
                 ### Now shrink from the max to normalize and grow to the mimic scale (instead of the CFG scale)
-                cfg_renormalized = (cfg_clamped / max_scalref) * min_scaleref
+                cfg_renormalized = (cfg_clamped / max_scaleref) * min_scaleref
             elif self.variability_measure == 'STD':
                 cfg_renormalized = (cfg_centered / cfg_scaleref) * min_scaleref
 

--- a/scripts/dynamic_thresholding.py
+++ b/scripts/dynamic_thresholding.py
@@ -43,6 +43,10 @@ class Script(scripts.Script):
             gr.HTML(value=f"<br>View <a style=\"border-bottom: 1px #00ffff dotted;\" href=\"https://github.com/mcmonkeyprojects/sd-dynamic-thresholding/wiki/Usage-Tips\">the wiki for usage tips.</a><br><br>", elem_id='dynthres_wiki_link')
             mimic_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='Mimic CFG Scale', value=7.0, elem_id='dynthres_mimic_scale')
             with gr.Accordion("Dynamic Thresholding Advanced Options", open=False, elem_id='dynthres_advanced_opts'):
+                separate_feature_channels = gr.Checkbox(value=True, label="Separate Feature Channels")
+                scaling_startpoint = gr.Radio(choices=[mode.name for mode in DynThreshScalingStartpoint], value=DynThreshScalingStartpoint.MEAN.name, label="Scaling Startpoint", type="index")
+                variability_measure = gr.Radio(choices=[mode.name for mode in DynThreshVariabilityMeasure], value=DynThreshVariabilityMeasure.AD.name, label="Variability Measure", type="index")
+                interpolate_phi = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label="Interpolate Phi",value=1.0)
                 threshold_percentile = gr.Slider(minimum=90.0, value=100.0, maximum=100.0, step=0.05, label='Top percentile of latents to clamp', elem_id='dynthres_threshold_percentile')
                 with gr.Row():
                     mimic_mode = gr.Dropdown(VALID_MODES, value="Constant", label="Mimic Scale Scheduler", elem_id='dynthres_mimic_mode')

--- a/scripts/dynamic_thresholding.py
+++ b/scripts/dynamic_thresholding.py
@@ -78,7 +78,7 @@ class Script(scripts.Script):
 
     last_id = 0
 
-    def process_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure, interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, prompts, seeds, subseeds):
+    def process_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, prompts, seeds, subseeds):
         enabled = getattr(p, 'dynthres_enabled', enabled)
         if not enabled:
             return
@@ -142,7 +142,7 @@ class Script(scripts.Script):
         if p.sampler is not None:
             p.sampler = sd_samplers.create_sampler(fixed_sampler_name, p.sd_model)
 
-    def postprocess_batch(self, p, enabled, mimic_scale,separate_feature_channels, scaling_startpoint,variability_measure, interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, images):
+    def postprocess_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, images):
         if not enabled or not hasattr(p, 'orig_sampler_name'):
             return
         p.sampler_name = p.orig_sampler_name

--- a/scripts/dynamic_thresholding.py
+++ b/scripts/dynamic_thresholding.py
@@ -13,6 +13,7 @@
 import gradio as gr
 import torch, traceback
 import dynthres_core
+from dynthres_core import DynThreshScalingStartpoint, DynThreshVariabilityMeasure
 from modules import scripts, script_callbacks, sd_samplers, sd_samplers_compvis, sd_samplers_kdiffusion, sd_samplers_common
 try:
     import dynthres_unipc
@@ -20,8 +21,7 @@ except Exception as e:
     print(f"\n\n======\nError! UniPC sampler support failed to load! Is your WebUI up to date?\n(Error: {e})\n======")
 
 ######################### Data values #########################
-VALID_MODES = ["Constant", "Linear Down", "Cosine Down", "Half Cosine Down", "Linear Up", "Cosine Up", "Half Cosine Up", "Power Up", "Power Down", "Linear Repeating", "Cosine Repeating", "Sawtooth"]
-MODES_WITH_VALUE = ["Power Up", "Power Down", "Linear Repeating", "Cosine Repeating", "Sawtooth"]
+VALID_MODES = ["Constant", "Linear Down", "Cosine Down", "Half Cosine Down", "Linear Up", "Cosine Up", "Half Cosine Up", "Power Up", "Power Down"]
 
 ######################### Script class entrypoint #########################
 class Script(scripts.Script):
@@ -33,27 +33,29 @@ class Script(scripts.Script):
         return scripts.AlwaysVisible
 
     def ui(self, is_img2img):
-        def vis_change(isVis):
-            return {"visible": isVis, "__type__": "update"}
         enabled = gr.Checkbox(value=False, label="Enable Dynamic Thresholding (CFG Scale Fix)")
         # "Dynamic Thresholding (CFG Scale Fix)"
         accordion = gr.Group(visible=False)
         with accordion:
-            gr.HTML(value=f"<br>View <a style=\"border-bottom: 1px #00ffff dotted;\" href=\"https://github.com/mcmonkeyprojects/sd-dynamic-thresholding/wiki/Usage-Tips\">the wiki for usage tips.</a><br><br>", elem_id='dynthres_wiki_link')
-            mimic_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='Mimic CFG Scale', value=7.0, elem_id='dynthres_mimic_scale')
-            with gr.Accordion("Dynamic Thresholding Advanced Options", open=False, elem_id='dynthres_advanced_opts'):
-                threshold_percentile = gr.Slider(minimum=90.0, value=100.0, maximum=100.0, step=0.05, label='Top percentile of latents to clamp', elem_id='dynthres_threshold_percentile')
-                with gr.Row():
-                    mimic_mode = gr.Dropdown(VALID_MODES, value="Constant", label="Mimic Scale Scheduler", elem_id='dynthres_mimic_mode')
-                    cfg_mode = gr.Dropdown(VALID_MODES, value="Constant", label="CFG Scale Scheduler", elem_id='dynthres_cfg_mode')
-                mimic_scale_min = gr.Slider(minimum=0.0, maximum=30.0, step=0.5, visible=False, label="Minimum value of the Mimic Scale Scheduler", elem_id='dynthres_mimic_scale_min')
-                cfg_scale_min = gr.Slider(minimum=0.0, maximum=30.0, step=0.5, visible=False, label="Minimum value of the CFG Scale Scheduler", elem_id='dynthres_cfg_scale_min')
-                sched_val = gr.Slider(minimum=0.0, maximum=40.0, step=0.5, value=4.0, visible=False, label="Scheduler Value", info="Value unique to the scheduler mode - for Power Up/Down, this is the power. For Linear/Cosine Repeating, this is the number of repeats per image.", elem_id='dynthres_sched_val')
-        def shouldShowSchedulerValue(cfgMode, mimicMode):
-            sched_vis = cfgMode in MODES_WITH_VALUE or mimicMode in MODES_WITH_VALUE
-            return vis_change(sched_vis), vis_change(mimicMode != "Constant"), vis_change(cfgMode != "Constant")
-        cfg_mode.change(shouldShowSchedulerValue, inputs=[cfg_mode, mimic_mode], outputs=[sched_val, mimic_scale_min, cfg_scale_min])
-        mimic_mode.change(shouldShowSchedulerValue, inputs=[cfg_mode, mimic_mode], outputs=[sched_val, mimic_scale_min, cfg_scale_min])
+            gr.HTML(value=f"<br>View <a style=\"border-bottom: 1px #00ffff dotted;\" href=\"https://github.com/mcmonkeyprojects/sd-dynamic-thresholding/wiki/Usage-Tips\">the wiki for usage tips.</a><br><br>")
+            mimic_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='Mimic CFG Scale', value=7.0)
+            with gr.Accordion("Dynamic Thresholding Advanced Options", open=False):
+                separate_feature_channels = gr.Checkbox(value=True, label="Separate Feature Channels")
+                scaling_startpoint = gr.Radio(choices=[mode.name for mode in DynThreshScalingStartpoint], value=DynThreshScalingStartpoint.MEAN.name, label="Scaling Startpoint", type="index")
+                variability_measure = gr.Radio(choices=[mode.name for mode in DynThreshVariabilityMeasure], value=DynThreshVariabilityMeasure.AD.name, label="Variability Measure", type="index")
+                interpolate_phi = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label="Interpolate Phi",value=1.0)
+                threshold_percentile = gr.Slider(minimum=90.0, value=100.0, maximum=100.0, step=0.05, label='Top percentile of latents to clamp')
+                mimic_mode = gr.Dropdown(VALID_MODES, value="Constant", label="Mimic Scale Scheduler")
+                mimic_scale_min = gr.Slider(minimum=0.0, maximum=30.0, step=0.5, label="Minimum value of the Mimic Scale Scheduler")
+                cfg_mode = gr.Dropdown(VALID_MODES, value="Constant", label="CFG Scale Scheduler")
+                cfg_scale_min = gr.Slider(minimum=0.0, maximum=30.0, step=0.5, label="Minimum value of the CFG Scale Scheduler")
+                power_val = gr.Slider(minimum=0.0, maximum=15.0, step=0.5, value=4.0, visible=False, label="Power Scheduler Value")
+        def shouldShowPowerScheduler(cfgMode, mimicMode):
+            if cfgMode in ["Power Up", "Power Down"] or mimicMode in ["Power Up", "Power Down"]:
+                return {"visible": True, "__type__": "update"}
+            return {"visible": False, "__type__": "update"}
+        cfg_mode.change(shouldShowPowerScheduler, inputs=[cfg_mode, mimic_mode], outputs=power_val)
+        mimic_mode.change(shouldShowPowerScheduler, inputs=[cfg_mode, mimic_mode], outputs=power_val)
         enabled.change(
             fn=lambda x: {"visible": x, "__type__": "update"},
             inputs=[enabled],
@@ -63,17 +65,21 @@ class Script(scripts.Script):
             (enabled, lambda d: gr.Checkbox.update(value="Dynamic thresholding enabled" in d)),
             (accordion, lambda d: gr.Accordion.update(visible="Dynamic thresholding enabled" in d)),
             (mimic_scale, "Mimic scale"),
+            (separate_feature_channels, "Separate Feature Channels"),
+            (scaling_startpoint,lambda d: gr.Radio.update(value=d.get("Scaling Startpoint", "MEAN"))),
+            (variability_measure,lambda d: gr.Radio.update(value=d.get("Variability Measure", "AD"))),
+            (interpolate_phi, "Interpolate Phi"),
             (threshold_percentile, "Threshold percentile"),
             (mimic_scale_min, "Mimic scale minimum"),
             (mimic_mode, lambda d: gr.Dropdown.update(value=d.get("Mimic mode", "Constant"))),
             (cfg_mode, lambda d: gr.Dropdown.update(value=d.get("CFG mode", "Constant"))),
             (cfg_scale_min, "CFG scale minimum"),
-            (sched_val, "Scheduler value"))
-        return [enabled, mimic_scale, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val]
+            (power_val, "Power scheduler value"))
+        return [enabled, mimic_scale,separate_feature_channels, scaling_startpoint,variability_measure,interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, power_val]
 
     last_id = 0
 
-    def process_batch(self, p, enabled, mimic_scale, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, prompts, seeds, subseeds):
+    def process_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure, interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, powerscale_power, batch_number, prompts, seeds, subseeds):
         enabled = getattr(p, 'dynthres_enabled', enabled)
         if not enabled:
             return
@@ -83,15 +89,23 @@ class Script(scripts.Script):
         if orig_sampler_name == 'UniPC' and p.enable_hr:
             raise RuntimeError(f"UniPC does not support Hires Fix. Auto WebUI silently swaps to DDIM for this, which DynThresh does not support. Please swap to a sampler capable of img2img processing for HR Fix to work.")
         mimic_scale = getattr(p, 'dynthres_mimic_scale', mimic_scale)
+        separate_feature_channels = getattr(p, 'dynthres_separate_feature_channels', separate_feature_channels)
+        scaling_startpoint = getattr(p, 'dynthres_scaling_startpoint', scaling_startpoint)
+        variability_measure = getattr(p, 'dynthres_variability_measure', variability_measure)
+        interpolate_phi = getattr(p, 'dynthres_interpolate_phi', interpolate_phi)
         threshold_percentile = getattr(p, 'dynthres_threshold_percentile', threshold_percentile)
         mimic_mode = getattr(p, 'dynthres_mimic_mode', mimic_mode)
         mimic_scale_min = getattr(p, 'dynthres_mimic_scale_min', mimic_scale_min)
         cfg_mode = getattr(p, 'dynthres_cfg_mode', cfg_mode)
         cfg_scale_min = getattr(p, 'dynthres_cfg_scale_min', cfg_scale_min)
         experiment_mode = getattr(p, 'dynthres_experiment_mode', 0)
-        sched_val = getattr(p, 'dynthres_scheduler_val', sched_val)
+        power_val = getattr(p, 'dynthres_power_val', powerscale_power)
         p.extra_generation_params["Dynamic thresholding enabled"] = True
         p.extra_generation_params["Mimic scale"] = mimic_scale
+        p.extra_generation_params["Separate Feature Channels"] = separate_feature_channels
+        p.extra_generation_params["Scaling Startpoint"] = DynThreshScalingStartpoint(scaling_startpoint).name
+        p.extra_generation_params["Variability Measure"] = DynThreshVariabilityMeasure(variability_measure).name
+        p.extra_generation_params["Interpolate Phi"] = interpolate_phi
         p.extra_generation_params["Threshold percentile"] = threshold_percentile
         p.extra_generation_params["Sampler"] = orig_sampler_name
         if mimic_mode != "Constant":
@@ -100,8 +114,8 @@ class Script(scripts.Script):
         if cfg_mode != "Constant":
             p.extra_generation_params["CFG mode"] = cfg_mode
             p.extra_generation_params["CFG scale minimum"] = cfg_scale_min
-        if cfg_mode in MODES_WITH_VALUE or mimic_mode in MODES_WITH_VALUE:
-            p.extra_generation_params["Scheduler value"] = sched_val
+        if cfg_mode in ["Power Up", "Power Down"] or mimic_mode in ["Power Up", "Power Down"]:
+            p.extra_generation_params["Power scheduler value"] = power_val
         # Note: the ID number is to protect the edge case of multiple simultaneous runs with different settings
         Script.last_id += 1
         fixed_sampler_name = f"{orig_sampler_name}_dynthres{Script.last_id}"
@@ -109,7 +123,7 @@ class Script(scripts.Script):
         threshold_percentile *= 0.01
         # Make a placeholder sampler
         sampler = sd_samplers.all_samplers_map[orig_sampler_name]
-        dtData = dynthres_core.DynThresh(mimic_scale, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, p.steps)
+        dtData = dynthres_core.DynThresh(mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure,interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, power_val, experiment_mode, p.steps)
         if orig_sampler_name == "UniPC":
             def uniPCConstructor(model):
                 return CustomVanillaSDSampler(dynthres_unipc.CustomUniPCSampler, model, dtData)
@@ -129,7 +143,7 @@ class Script(scripts.Script):
         if p.sampler is not None:
             p.sampler = sd_samplers.create_sampler(fixed_sampler_name, p.sd_model)
 
-    def postprocess_batch(self, p, enabled, mimic_scale, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, images):
+    def postprocess_batch(self, p, enabled, mimic_scale,separate_feature_channels, scaling_startpoint,variability_measure, interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, powerscale_power, batch_number, images):
         if not enabled or not hasattr(p, 'orig_sampler_name'):
             return
         p.sampler_name = p.orig_sampler_name
@@ -157,19 +171,6 @@ class CustomCFGDenoiser(sd_samplers_kdiffusion.CFGDenoiser):
         weights = torch.tensor(conds_list, device=uncond.device).select(2, 1)
         weights = weights.reshape(*weights.shape, 1, 1, 1)
         self.main_class.step = self.step
-        
-        if self.main_class.experiment_mode >= 4 and self.main_class.experiment_mode <= 5:
-            # https://arxiv.org/pdf/2305.08891.pdf "Rescale CFG". It's not good, but if you want to test it, just set experiment_mode = 4 + phi.
-            denoised = torch.clone(denoised_uncond)
-            fi = self.main_class.experiment_mode - 4.0
-            for i, conds in enumerate(conds_list):
-                for cond_index, weight in conds:
-                    xcfg = (denoised_uncond[i] + (x_out[cond_index] - denoised_uncond[i]) * (cond_scale * weight))
-                    xrescaled = xcfg * (torch.std(x_out[cond_index]) / torch.std(xcfg))
-                    xfinal = fi * xrescaled + (1.0 - fi) * xcfg
-                    denoised[i] = xfinal
-            return denoised
-
         return self.main_class.dynthresh(x_out[:-uncond.shape[0]], denoised_uncond, cond_scale, weights)
 
 ######################### XYZ Plot Script Support logic #########################
@@ -186,14 +187,40 @@ def make_axis_options():
         for x in xs:
             if x not in VALID_MODES:
                 raise RuntimeError(f"Unknown Scheduler: {x}")
+
+    def confirm_startpoint_choices(p, xs):
+        for x in xs:
+            if x not in [mode.name for mode in DynThreshScalingStartpoint]:
+                raise RuntimeError(f"Unknown Mode: {x}")
+
+
+    def confirm_variability_mesure_choices(p, xs):
+        for x in xs:
+            if x not in [mode.name for mode in DynThreshVariabilityMeasure]:
+                raise RuntimeError(f"Unknown Mode: {x}")
+
+    def apply_field_enum(field, EnumClass):
+        def fun(p, x, xs):
+            enum_x = EnumClass[x]
+            setattr(p, field, enum_x)
+
+        return fun
+
     extra_axis_options = [
         xyz_grid.AxisOption("[DynThres] Mimic Scale", float, apply_mimic_scale),
+        xyz_grid.AxisOption("[DynThres] Separate Feature Channels", int,
+                            xyz_grid.apply_field("dynthres_separate_feature_channels")),
+        xyz_grid.AxisOption("[DynThres] Scaling Startpoint", str, apply_field_enum("dynthres_scaling_startpoint", DynThreshScalingStartpoint),
+                            confirm=confirm_startpoint_choices, choices=lambda:[mode.name for mode in DynThreshScalingStartpoint]),
+        xyz_grid.AxisOption("[DynThres] Variability Measure", str, apply_field_enum("dynthres_variability_measure", DynThreshVariabilityMeasure),
+                            confirm=confirm_variability_mesure_choices, choices=lambda:[mode.name for mode in DynThreshVariabilityMeasure]),
+        xyz_grid.AxisOption("[DynThres] Interpolate Phi", float, xyz_grid.apply_field("dynthres_interpolate_phi")),
         xyz_grid.AxisOption("[DynThres] Threshold Percentile", float, xyz_grid.apply_field("dynthres_threshold_percentile")),
         xyz_grid.AxisOption("[DynThres] Mimic Scheduler", str, xyz_grid.apply_field("dynthres_mimic_mode"), confirm=confirm_scheduler, choices=lambda: VALID_MODES),
         xyz_grid.AxisOption("[DynThres] Mimic minimum", float, xyz_grid.apply_field("dynthres_mimic_scale_min")),
         xyz_grid.AxisOption("[DynThres] CFG Scheduler", str, xyz_grid.apply_field("dynthres_cfg_mode"), confirm=confirm_scheduler, choices=lambda: VALID_MODES),
         xyz_grid.AxisOption("[DynThres] CFG minimum", float, xyz_grid.apply_field("dynthres_cfg_scale_min")),
-        xyz_grid.AxisOption("[DynThres] Scheduler value", float, xyz_grid.apply_field("dynthres_scheduler_val"))
+        xyz_grid.AxisOption("[DynThres] Power scheduler value", float, xyz_grid.apply_field("dynthres_power_val"))
     ]
     if not any("[DynThres]" in x.label for x in xyz_grid.axis_options):
         xyz_grid.axis_options.extend(extra_axis_options)

--- a/scripts/dynamic_thresholding.py
+++ b/scripts/dynamic_thresholding.py
@@ -45,7 +45,7 @@ class Script(scripts.Script):
                 separate_feature_channels = gr.Checkbox(value=True, label="Separate Feature Channels")
                 scaling_startpoint = gr.Radio(choices=['ZERO', 'MEAN'], value='MEAN', label="Scaling Startpoint", type="index")
                 variability_measure = gr.Radio(choices=['STD', 'AD'], value='AD', label="Variability Measure", type="index")
-                interpolate_phi = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label="Interpolate Phi",value=1.0)
+                interpolate_phi = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label="Interpolate Phi", value=1.0)
                 threshold_percentile = gr.Slider(minimum=90.0, value=100.0, maximum=100.0, step=0.05, label='Top percentile of latents to clamp', elem_id='dynthres_threshold_percentile')
                 with gr.Row():
                     mimic_mode = gr.Dropdown(VALID_MODES, value="Constant", label="Mimic Scale Scheduler", elem_id='dynthres_mimic_mode')
@@ -173,7 +173,7 @@ class CustomCFGDenoiser(sd_samplers_kdiffusion.CFGDenoiser):
         weights = torch.tensor(conds_list, device=uncond.device).select(2, 1)
         weights = weights.reshape(*weights.shape, 1, 1, 1)
         self.main_class.step = self.step
-
+        
         if self.main_class.experiment_mode >= 4 and self.main_class.experiment_mode <= 5:
             # https://arxiv.org/pdf/2305.08891.pdf "Rescale CFG". It's not good, but if you want to test it, just set experiment_mode = 4 + phi.
             denoised = torch.clone(denoised_uncond)
@@ -202,7 +202,6 @@ def make_axis_options():
         for x in xs:
             if x not in VALID_MODES:
                 raise RuntimeError(f"Unknown Scheduler: {x}")
-
     extra_axis_options = [
         xyz_grid.AxisOption("[DynThres] Mimic Scale", float, apply_mimic_scale),
         xyz_grid.AxisOption("[DynThres] Separate Feature Channels", int,

--- a/scripts/dynamic_thresholding.py
+++ b/scripts/dynamic_thresholding.py
@@ -78,7 +78,7 @@ class Script(scripts.Script):
 
     last_id = 0
 
-    def process_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, prompts, seeds, subseeds):
+    def process_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, prompts, seeds, subseeds):
         enabled = getattr(p, 'dynthres_enabled', enabled)
         if not enabled:
             return
@@ -122,7 +122,7 @@ class Script(scripts.Script):
         threshold_percentile *= 0.01
         # Make a placeholder sampler
         sampler = sd_samplers.all_samplers_map[orig_sampler_name]
-        dtData = dynthres_core.DynThresh(mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure, interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, p.steps)
+        dtData = dynthres_core.DynThresh(mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, p.steps)
         if orig_sampler_name == "UniPC":
             def uniPCConstructor(model):
                 return CustomVanillaSDSampler(dynthres_unipc.CustomUniPCSampler, model, dtData)
@@ -142,7 +142,7 @@ class Script(scripts.Script):
         if p.sampler is not None:
             p.sampler = sd_samplers.create_sampler(fixed_sampler_name, p.sd_model)
 
-    def postprocess_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi,threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, images):
+    def postprocess_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, images):
         if not enabled or not hasattr(p, 'orig_sampler_name'):
             return
         p.sampler_name = p.orig_sampler_name

--- a/scripts/dynamic_thresholding.py
+++ b/scripts/dynamic_thresholding.py
@@ -42,17 +42,19 @@ class Script(scripts.Script):
             gr.HTML(value=f"<br>View <a style=\"border-bottom: 1px #00ffff dotted;\" href=\"https://github.com/mcmonkeyprojects/sd-dynamic-thresholding/wiki/Usage-Tips\">the wiki for usage tips.</a><br><br>", elem_id='dynthres_wiki_link')
             mimic_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='Mimic CFG Scale', value=7.0, elem_id='dynthres_mimic_scale')
             with gr.Accordion("Dynamic Thresholding Advanced Options", open=False, elem_id='dynthres_advanced_opts'):
-                separate_feature_channels = gr.Checkbox(value=True, label="Separate Feature Channels")
-                scaling_startpoint = gr.Radio(choices=['ZERO', 'MEAN'], value='MEAN', label="Scaling Startpoint", type="index")
-                variability_measure = gr.Radio(choices=['STD', 'AD'], value='AD', label="Variability Measure", type="index")
-                interpolate_phi = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label="Interpolate Phi", value=1.0)
-                threshold_percentile = gr.Slider(minimum=90.0, value=100.0, maximum=100.0, step=0.05, label='Top percentile of latents to clamp', elem_id='dynthres_threshold_percentile')
+                with gr.Row():
+                    threshold_percentile = gr.Slider(minimum=90.0, value=100.0, maximum=100.0, step=0.05, label='Top percentile of latents to clamp', elem_id='dynthres_threshold_percentile')
+                    interpolate_phi = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label="Interpolate Phi", value=1.0, elem_id='dynthres_interpolate_phi')
                 with gr.Row():
                     mimic_mode = gr.Dropdown(VALID_MODES, value="Constant", label="Mimic Scale Scheduler", elem_id='dynthres_mimic_mode')
                     cfg_mode = gr.Dropdown(VALID_MODES, value="Constant", label="CFG Scale Scheduler", elem_id='dynthres_cfg_mode')
                 mimic_scale_min = gr.Slider(minimum=0.0, maximum=30.0, step=0.5, visible=False, label="Minimum value of the Mimic Scale Scheduler", elem_id='dynthres_mimic_scale_min')
                 cfg_scale_min = gr.Slider(minimum=0.0, maximum=30.0, step=0.5, visible=False, label="Minimum value of the CFG Scale Scheduler", elem_id='dynthres_cfg_scale_min')
                 sched_val = gr.Slider(minimum=0.0, maximum=40.0, step=0.5, value=4.0, visible=False, label="Scheduler Value", info="Value unique to the scheduler mode - for Power Up/Down, this is the power. For Linear/Cosine Repeating, this is the number of repeats per image.", elem_id='dynthres_sched_val')
+                with gr.Row():
+                    separate_feature_channels = gr.Checkbox(value=True, label="Separate Feature Channels", elem_id='dynthres_separate_feature_channels')
+                    scaling_startpoint = gr.Radio(["ZERO", "MEAN"], value="MEAN", label="Scaling Startpoint", elem_id='dynthres_scaling_startpoint')
+                    variability_measure = gr.Radio(["STD", "AD"], value="AD", label="Variability Measure", elem_id='dynthres_variability_measure')
         def shouldShowSchedulerValue(cfgMode, mimicMode):
             sched_vis = cfgMode in MODES_WITH_VALUE or mimicMode in MODES_WITH_VALUE
             return vis_change(sched_vis), vis_change(mimicMode != "Constant"), vis_change(cfgMode != "Constant")
@@ -77,11 +79,11 @@ class Script(scripts.Script):
             (cfg_mode, lambda d: gr.Dropdown.update(value=d.get("CFG mode", "Constant"))),
             (cfg_scale_min, "CFG scale minimum"),
             (sched_val, "Scheduler value"))
-        return [enabled, mimic_scale,separate_feature_channels, scaling_startpoint,variability_measure,interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val]
+        return [enabled, mimic_scale, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi]
 
     last_id = 0
 
-    def process_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, prompts, seeds, subseeds):
+    def process_batch(self, p, enabled, mimic_scale, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi, batch_number, prompts, seeds, subseeds):
         enabled = getattr(p, 'dynthres_enabled', enabled)
         if not enabled:
             return
@@ -125,7 +127,7 @@ class Script(scripts.Script):
         threshold_percentile *= 0.01
         # Make a placeholder sampler
         sampler = sd_samplers.all_samplers_map[orig_sampler_name]
-        dtData = dynthres_core.DynThresh(mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, p.steps)
+        dtData = dynthres_core.DynThresh(mimic_scale, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, p.steps, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi)
         if orig_sampler_name == "UniPC":
             def uniPCConstructor(model):
                 return CustomVanillaSDSampler(dynthres_unipc.CustomUniPCSampler, model, dtData)
@@ -145,7 +147,7 @@ class Script(scripts.Script):
         if p.sampler is not None:
             p.sampler = sd_samplers.create_sampler(fixed_sampler_name, p.sd_model)
 
-    def postprocess_batch(self, p, enabled, mimic_scale, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, batch_number, images):
+    def postprocess_batch(self, p, enabled, mimic_scale, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, separate_feature_channels, scaling_startpoint, variability_measure, interpolate_phi, batch_number, images):
         if not enabled or not hasattr(p, 'orig_sampler_name'):
             return
         p.sampler_name = p.orig_sampler_name

--- a/scripts/dynamic_thresholding.py
+++ b/scripts/dynamic_thresholding.py
@@ -113,7 +113,7 @@ class Script(scripts.Script):
         if cfg_mode != "Constant":
             p.extra_generation_params["CFG mode"] = cfg_mode
             p.extra_generation_params["CFG scale minimum"] = cfg_scale_min
-        if cfg_mode in [MODES_WITH_VALUE or mimic_mode in MODES_WITH_VALUE:
+        if cfg_mode in MODES_WITH_VALUE or mimic_mode in MODES_WITH_VALUE:
             p.extra_generation_params["Scheduler value"] = sched_val
         # Note: the ID number is to protect the edge case of multiple simultaneous runs with different settings
         Script.last_id += 1
@@ -122,7 +122,7 @@ class Script(scripts.Script):
         threshold_percentile *= 0.01
         # Make a placeholder sampler
         sampler = sd_samplers.all_samplers_map[orig_sampler_name]
-        dtData = dynthres_core.DynThresh(mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure,interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, p.steps)
+        dtData = dynthres_core.DynThresh(mimic_scale, separate_feature_channels, scaling_startpoint,variability_measure, interpolate_phi, threshold_percentile, mimic_mode, mimic_scale_min, cfg_mode, cfg_scale_min, sched_val, experiment_mode, p.steps)
         if orig_sampler_name == "UniPC":
             def uniPCConstructor(model):
                 return CustomVanillaSDSampler(dynthres_unipc.CustomUniPCSampler, model, dtData)


### PR DESCRIPTION
Credit to @ashen-sensored for original contribution and documentation found [here](https://github.com/ashen-sensored/sd-dynamic-thresholding-rcfg)

I've merged the changes from ashen's repo, cleaned up some minor missing spaces in the code, and synchronised them to up commit 27700fd. All options seem to work fine together in testing.

I've personally been using the extra functionality from ashen's repo and I think this will be a valuable feature to have in the main extension, but unfortunately development on their branch and other repos from ashen have been silent for a while.

Due to these circumstances, as a disclaimer I'm not affiliated with ashen and this PR has been made without ashen's explicit sign-off.

These changes should however satisfy [this issue](https://github.com/ashen-sensored/sd-dynamic-thresholding-rcfg/issues/1)