### PR TITLE
fix to sync original checkbox state when infotext loaded

### DIFF
--- a/javascript/active.js
+++ b/javascript/active.js
@@ -12,6 +12,7 @@
             badge.checked = checkbox.checked;
             badge.addEventListener('click', (e) => {
                 checkbox.checked = !checkbox.checked;
+                badge.checked = checkbox.checked;
                 checkbox.dispatchEvent(new Event('change'));
                 e.stopPropagation();
             });
@@ -23,7 +24,7 @@
             space.innerHTML = "&nbsp;";
             span.insertBefore(space, badge.nextSibling);
 
-            checkbox.addEventListener('click', () => {
+            checkbox.addEventListener('change', () => {
                 let badge = accordion.querySelector('.label-wrap span input');
                 badge.checked = checkbox.checked;
             });


### PR DESCRIPTION
when infotext is loaded from `params.txt`, the state `enabled` checkbox of Dynamic Threshold will be changed but no event fired. I guess this is a bug of Gradio checkbox. (and I assume the `change` event should be fired)

this hack will synchronize the original checkbox state with the fake checkbox.