### PR TITLE
Accomodate SD.Next modules refactor

### DIFF
--- a/dynthres_unipc.py
+++ b/dynthres_unipc.py
@@ -3,7 +3,18 @@ import torch
 import math
 import traceback
 from modules import shared
-from modules.models.diffusion import uni_pc
+try:
+    from modules.models.diffusion import uni_pc
+except Exception as e:
+    try:
+        from modules.unipc import sampler
+        class SDNextUniPC(object):
+            def __init__(self):
+                self.sampler = sampler
+                self.uni_pc = sampler
+        uni_pc = SDNextUniPC()
+    except Exception as ex:
+        print(f"\n\n======\nError! WebUI and SD.Next UniPC sampler support failed to load.\n(Errors: {e}, {ex})\n======")
 
 ######################### UniPC Implementation logic #########################
 

--- a/dynthres_unipc.py
+++ b/dynthres_unipc.py
@@ -6,15 +6,12 @@ from modules import shared
 try:
     from modules.models.diffusion import uni_pc
 except Exception as e:
-    try:
-        from modules.unipc import sampler
-        class SDNextUniPC(object):
-            def __init__(self):
-                self.sampler = sampler
-                self.uni_pc = sampler
-        uni_pc = SDNextUniPC()
-    except Exception as ex:
-        print(f"\n\n======\nError! WebUI and SD.Next UniPC sampler support failed to load.\n(Errors: {e}, {ex})\n======")
+    from modules.unipc import sampler
+    class VladUniPC(object):
+        def __init__(self):
+            self.sampler = sampler
+            self.uni_pc = sampler
+    uni_pc = VladUniPC()
 
 ######################### UniPC Implementation logic #########################
 


### PR DESCRIPTION
Fix for #78 - create a simple `uni_pc` object to replace `modules.models.diffusion.uni_pc` so `uni_pc.sampler` and `uni_pc.uni_pc` both resolve to the new `modules.unipc.sampler` object.