### PR TITLE
Update dynthres_comfyui.py

### DIFF
--- a/dynthres_comfyui.py
+++ b/dynthres_comfyui.py
@@ -34,8 +34,8 @@ class DynamicThresholdingComfyNode:
             cond = input - args["cond"]
             uncond = input - args["uncond"]
             cond_scale = args["cond_scale"]
-            time_step = args["timestep"]
-            dynamic_thresh.step = 999 - time_step[0]
+            time_step = model.model.model_sampling.timestep(args["sigma"])
+            dynamic_thresh.step = 999 - time_step
 
             return input - dynamic_thresh.dynthresh(cond, uncond, cond_scale, None)
 
@@ -68,8 +68,8 @@ class DynamicThresholdingSimpleComfyNode:
             cond = input - args["cond"]
             uncond = input - args["uncond"]
             cond_scale = args["cond_scale"]
-            time_step = args["timestep"]
-            dynamic_thresh.step = 999 - time_step[0]
+            time_step = model.model.model_sampling.timestep(args["sigma"])
+            dynamic_thresh.step = 999
 
             return input - dynamic_thresh.dynthresh(cond, uncond, cond_scale, None)
 

--- a/dynthres_comfyui.py
+++ b/dynthres_comfyui.py
@@ -69,7 +69,7 @@ class DynamicThresholdingSimpleComfyNode:
             uncond = input - args["uncond"]
             cond_scale = args["cond_scale"]
             time_step = model.model.model_sampling.timestep(args["sigma"])
-            dynamic_thresh.step = 999
+            dynamic_thresh.step = 999 - time_step
 
             return input - dynamic_thresh.dynthresh(cond, uncond, cond_scale, None)
 


### PR DESCRIPTION
comfyui timestep arg returns the sigma instead of the timestep. This messes up the timestep schedule of the cfg thresholding script.

Thanks to piezo for helping me figure out how to convert sigma to timestep.