### PR TITLE
Fix xyz module name

### DIFF
--- a/scripts/dynamic_thresholding.py
+++ b/scripts/dynamic_thresholding.py
@@ -234,7 +234,7 @@ class CustomCFGDenoiser(cfgdenoisekdiff):
 ######################### XYZ Plot Script Support logic #########################
 
 def make_axis_options():
-    xyz_grid = [x for x in scripts.scripts_data if x.script_class.__module__ == "xyz_grid.py"][0].module
+    xyz_grid = [x for x in scripts.scripts_data if x.script_class.__module__ in ("xyz_grid.py", "scripts.xyz_grid")][0].module
     def apply_mimic_scale(p, x, xs):
         if x != 0:
             setattr(p, "dynthres_enabled", True)


### PR DESCRIPTION
`script_class.__module__` is changed from `foo.py` to `scripts.foo` in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15532#issuecomment-2068006783.

This PR updates the `__module__` matching.